### PR TITLE
Add possibility to use custom validator.

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -16,3 +16,6 @@ jobs:
         run: composer install
       - name: Execute test suite
         run: composer test
+      - name: Send coverage to Scrutinizer CI
+        if: ${{ always() && matrix.php-version == '8.1' }}
+        run: php vendor/bin/ocular code-coverage:upload --format=php-clover build/coverage.xml

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     name: Run tests in PHP ${{ matrix.php-version }}
     runs-on: ubuntu-latest
-    container: FTI-Herbert/php-dev:${{ matrix.php-version }}
+    container: 1maa/php-dev:${{ matrix.php-version }}
     strategy:
       fail-fast: false
       matrix:
@@ -16,6 +16,3 @@ jobs:
         run: composer install
       - name: Execute test suite
         run: composer test
-      - name: Send coverage to Scrutinizer CI
-        if: ${{ always() && matrix.php-version == '8.1' }}
-        run: php vendor/bin/ocular code-coverage:upload --format=php-clover build/coverage.xml

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     name: Run tests in PHP ${{ matrix.php-version }}
     runs-on: ubuntu-latest
-    container: 1maa/php-dev:${{ matrix.php-version }}
+    container: FTI-Herbert/php-dev:${{ matrix.php-version }}
     strategy:
       fail-fast: false
       matrix:

--- a/src/Server.php
+++ b/src/Server.php
@@ -166,7 +166,7 @@ final class Server
     {
         \assert($input->isArray());
 
-        return \is_int($this->batchLimit) && $this->batchLimit < count($input->data());
+        return \is_int($this->batchLimit) && $this->batchLimit < \count($input->data());
     }
 
     private static function end(Response $response, Request $request = null): ?string

--- a/src/Server.php
+++ b/src/Server.php
@@ -166,12 +166,12 @@ final class Server
     {
         \assert($input->isArray());
 
-        return is_int($this->batchLimit) && $this->batchLimit < count($input->data());
+        return \is_int($this->batchLimit) && $this->batchLimit < count($input->data());
     }
 
     private static function end(Response $response, Request $request = null): ?string
     {
         return $request instanceof Request && null === $request->id() ?
-            null : json_encode($response);
+            null : \json_encode($response);
     }
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -76,12 +76,12 @@ final class Server
         $input = Input::fromString($raw);
 
         if (!$input->parsable()) {
-            return self::end(Error::parsing());
+            return static::end(Error::parsing());
         }
 
         if ($input->isArray()) {
             if ($this->tooManyBatchRequests($input)) {
-                return self::end(Error::tooManyBatchRequests($this->batchLimit));
+                return static::end(Error::tooManyBatchRequests($this->batchLimit));
             }
 
             return $this->batch($input);
@@ -113,13 +113,13 @@ final class Server
     private function single(Input $input): ?string
     {
         if (!$input->isRpcRequest()) {
-            return self::end(Error::invalidRequest());
+            return static::end(Error::invalidRequest());
         }
 
         $request = new Request($input);
 
-        if (!array_key_exists($request->method(), $this->methods)) {
-            return self::end(Error::unknownMethod($request->id()), $request);
+        if (!\array_key_exists($request->method(), $this->methods)) {
+            return static::end(Error::unknownMethod($request->id()), $request);
         }
 
         try {
@@ -141,7 +141,7 @@ final class Server
             }, \array_keys($this->middlewares))
         );
 
-        return static::end($stack($request), $request);
+        return self::end($stack($request), $request);
     }
 
     /**
@@ -166,12 +166,12 @@ final class Server
     {
         \assert($input->isArray());
 
-        return \is_int($this->batchLimit) && $this->batchLimit < \count($input->data());
+        return is_int($this->batchLimit) && $this->batchLimit < count($input->data());
     }
 
     private static function end(Response $response, Request $request = null): ?string
     {
         return $request instanceof Request && null === $request->id() ?
-            null : \json_encode($response);
+            null : json_encode($response);
     }
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -141,7 +141,7 @@ final class Server
             }, \array_keys($this->middlewares))
         );
 
-        return self::end($stack($request), $request);
+        return static::end($stack($request), $request);
     }
 
     /**


### PR DESCRIPTION
With this little changes, it is possible to use a custom json schema validator.
The custom validator is optional and can be configured via the PSR-11 container.

This will not change the response or behavior of the json/rpc server!
It just give you(optional) the full feature of json schema.
See:
https://opis.io/json-schema/1.x/filters.html
https://opis.io/json-schema/1.x/php-format.html
https://opis.io/json-schema/1.x/php-media-type.html